### PR TITLE
caza: overlays: set physical_power_button_center_screen_location_y

### DIFF
--- a/rro_overlays/SystemUIResCommon_Sys/res/values/dimens.xml
+++ b/rro_overlays/SystemUIResCommon_Sys/res/values/dimens.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     SPDX-FileCopyrightText: 2025 The LineageOS Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- Location on the screen of the center of the physical power button. -->
+    <dimen name="physical_power_button_center_screen_location_y">1120px</dimen>
+
+</resources>


### PR DESCRIPTION
AOD <-> Lockscreen transitions will draw a circle anchored at this point (vertically) on the screen to the power button location.

location may slightly differ for tiro (REDMAGIC 9 Pro), as i only own cerro