### PR TITLE
Update vendor.prop to  Fix China Broadnet (VoLTE Voice/SMS) support

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -380,5 +380,13 @@ PRODUCT_PACKAGES += \
     firmware_wlan_mac.bin_symlink \
     firmware_WCNSS_qcom_cfg.ini_symlink
 
+#
+# MindTheGapps
+#
+WITH_GAPPS ?= false
+ifeq ($(WITH_GAPPS),true)
+  $(call inherit-product-if-exists,  vendor/gapps/arm64/arm64-vendor.mk )
+endif
+
 # Inherit from proprietary targets
 $(call inherit-product, vendor/nubia/caza/caza-vendor.mk)

--- a/vendor.prop
+++ b/vendor.prop
@@ -259,6 +259,13 @@ persist.vendor.radio.testTimerB=30
 persist.vendor.radio.voice_on_lte=1
 ro.telephony.default_network=33,33
 
+persist.dbg.ims_volte_enable=1
+persist.dbg.volte_avail_ovr=1
+persist.dbg.ims_vt_enable=1
+persist.dbg.vt_avail_ovr=1
+persist.radio.calls.on.ims=1
+persist.radio.jbims=1
+
 # SoC
 ro.soc.manufacturer=QTI
 


### PR DESCRIPTION
5G can be used normally, but calls and sms cannot be made. 
I use adb root test prop:
setprop persist.dbg.ims_volte_enable 1
setprop persist.dbg.volte_avail_ovr 1
setprop persist.dbg.ims_vt_enable 1
setprop persist.dbg.vt_avail_ovr 1
setprop persist.radio.calls.on.ims 1
setprop persist.radio.jbims 1

and reboot ,test fixed, No other issues found